### PR TITLE
Added ability to write to stream  as PNG

### DIFF
--- a/src/main/java/wordcloud/WordCloud.java
+++ b/src/main/java/wordcloud/WordCloud.java
@@ -25,6 +25,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -123,6 +124,32 @@ public class WordCloud {
             ImageIO.write(bufferedImage, extension, new File(outputFileName));
         } catch (IOException e) {
             LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Write to output stream as PNG
+     *
+     * @param outputStream the output stream to write the image data to
+     */
+    public void writeToStreamAsPNG(final OutputStream outputStream) {
+        writeToStream("png", outputStream);
+    }
+
+    /**
+     * Write wordcloud image data to stream in the given format
+     *
+     * @param format       the image format
+     * @param outputStream the output stream to write image data to
+     */
+    public void writeToStream(final String format, final OutputStream outputStream) {
+        try {
+            LOGGER.debug("Writing WordCloud image data to output stream");
+            ImageIO.write(bufferedImage, format, outputStream);
+            LOGGER.debug("Done writing WordCloud image data to output stream");
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+            throw new RuntimeException("Could not write wordcloud to outputstream due to an IOException", e);
         }
     }
 

--- a/src/test/java/wordcloud/WordCloudTest.java
+++ b/src/test/java/wordcloud/WordCloudTest.java
@@ -1,0 +1,49 @@
+package wordcloud;
+
+import org.junit.Test;
+import wordcloud.bg.RectangleBackground;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class WordCloudTest {
+
+    public static final List<WordFrequency> WORD_FREQUENCIES = Arrays.asList(new WordFrequency("apple", 22),
+                                                                             new WordFrequency("baby", 3),
+                                                                             new WordFrequency("back", 15),
+                                                                             new WordFrequency("bear", 9),
+                                                                             new WordFrequency("boy", 26));
+
+    @Test
+    public void testWriteToStreamAsPNG() throws Exception {
+
+        final WordCloud wordCloud = new WordCloud(200, 200, CollisionMode.PIXEL_PERFECT);
+        wordCloud.build(WORD_FREQUENCIES);
+        wordCloud.setPadding(2);
+        wordCloud.setBackground(new RectangleBackground(120, 120));
+
+
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        wordCloud.writeToStreamAsPNG(byteArrayOutputStream);
+
+        final byte[] bytes = byteArrayOutputStream.toByteArray();
+        assertNotEquals(0, bytes.length);
+
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        final ImageInputStream imageInputStream = ImageIO.createImageInputStream(byteArrayInputStream);
+        final Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
+        assertTrue(imageReaders.hasNext());
+        final ImageReader imageReader = imageReaders.next();
+        assertEquals("png", imageReader.getFormatName());
+    }
+
+
+}


### PR DESCRIPTION
Added functionality for writing WordCloud image data to an input stream. This makes the library even more convenient to use in on-line applications 