### PR TITLE
scope of log4j binding set to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,13 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>1.7.25</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>1.2.17</version>
-                <scope>runtime</scope>
+                <scope>test</scope>
             </dependency>
 
             <!-- misc -->


### PR DESCRIPTION
Set the scope of log4j binding to test. So the program is logger framework agnostic and other programs could use own logger over slf4j such as logback.