### PR TITLE
Updates several dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please feel free to jump in and help improve Kumo! There are many places for per
 <dependency>
     <groupId>com.kennycason</groupId>
     <artifactId>kumo-core</artifactId>
-    <version>1.13</version>
+    <version>1.14-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -43,7 +43,7 @@ Include `kumo-tokenizers` if you want Chinese serialization. More languages to c
 <dependency>
     <groupId>com.kennycason</groupId>
     <artifactId>kumo-tokenizers</artifactId>
-    <version>1.13</version>
+    <version>1.14-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/kumo-api/pom.xml
+++ b/kumo-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kumo</artifactId>
         <groupId>com.kennycason</groupId>
-        <version>1.13</version>
+        <version>1.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kumo-cli/pom.xml
+++ b/kumo-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kumo</artifactId>
         <groupId>com.kennycason</groupId>
-        <version>1.13</version>
+        <version>1.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kumo-core/pom.xml
+++ b/kumo-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.kennycason</groupId>
         <artifactId>kumo</artifactId>
-        <version>1.13</version>
+        <version>1.14-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kumo-tokenizers/pom.xml
+++ b/kumo-tokenizers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kumo</artifactId>
         <groupId>com.kennycason</groupId>
-        <version>1.13</version>
+        <version>1.14-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,17 +87,17 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.8.2</version>
+                <version>1.11.3</version>
             </dependency>
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.48</version>
+                <version>1.72</version>
             </dependency>
             <dependency>
                 <groupId>com.github.davidmoten</groupId>
                 <artifactId>rtree</artifactId>
-                <version>0.8.0.1</version>
+                <version>0.8.6</version>
             </dependency>
 
             <!-- test -->

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <source>${java.source}</source>
                         <target>${java.target}</target>
@@ -191,7 +191,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -203,7 +203,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
@@ -230,7 +230,7 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.4</version>
+                    <version>1.6.8</version>
                     <extensions>true</extensions>
                     <configuration>
                         <serverId>ossrh</serverId>
@@ -241,7 +241,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.22.0</version>
                     <configuration>
                         <argLine>-Xms256m -Xmx768m -XX:+CMSClassUnloadingEnabled -Dfile.encoding=UTF-8</argLine>
                         <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kennycason</groupId>
     <artifactId>kumo</artifactId>
-    <version>1.13</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>Kumo's goal is to create a powerful and user friendly Word Cloud API in Java. Kumo directly generates an image file without the need to create an applet (as many other libraries do).</description>

--- a/script/kumo.rb
+++ b/script/kumo.rb
@@ -1,14 +1,14 @@
 class Kumo < Formula
   desc "Word Clouds in Java"
   homepage "https://github.com/kennycason/kumo"
-  url "https://search.maven.org/remotecontent?filepath=com/kennycason/kumo-cli/1.13/kumo-cli-1.13.jar"
+  url "https://search.maven.org/remotecontent?filepath=com/kennycason/kumo-cli/1.14-SNAPSHOT/kumo-cli-1.14-SNAPSHOT.jar"
   sha256 "c9ad525f7d6aec9e2c06cf10017e1e533f43b1b3c4df5aa0d4b137f8d563c5c6"
 
   depends_on :java => "1.8+"
 
   def install
-    libexec.install "kumo-cli-1.13.jar"
-    bin.write_jar_script libexec/"kumo-cli-1.13.jar", "kumo"
+    libexec.install "kumo-cli-1.14-SNAPSHOT.jar"
+    bin.write_jar_script libexec/"kumo-cli-1.14-SNAPSHOT.jar", "kumo"
   end
 
   test do


### PR DESCRIPTION
## Dependencies
- updates jsoup to 1.11.3 (was 1.8.2)  …
- updates jcommander to 1.72 (was 1.48)
- updates to rtree 0.8.6 (was 0.8.0.1)

## Maven Plugins
- updates compiler plugin to 3.8.0 (was 3.5.1)
- updates source plugin to 3.0.1 (was 2.4)
- updates javadoc plugin to 3.0.1 (was 2.10.3)
- updates nexus plugin to 1.6.8 (was 1.6.4)
- updates surefire plugin to 2.22.0 (was 2.20)


@kennycason Please consider a `1.14` release if this PR is accepted. 