### PR TITLE
Replace usage of Math.sqrt with Math.log

### DIFF
--- a/kumo-core/src/main/java/com/kennycason/kumo/font/scale/LogFontScalar.java
+++ b/kumo-core/src/main/java/com/kennycason/kumo/font/scale/LogFontScalar.java
@@ -15,7 +15,7 @@ public class LogFontScalar implements FontScalar {
 
     @Override
     public float scale(final int value, final int minValue, final int maxValue) {
-        final double leftSpan = Math.sqrt(maxValue) - Math.sqrt(minValue);
+        final double leftSpan = Math.log(maxValue) - Math.log(minValue);
         final double rightSpan = maxFont - minFont;
 
         // Convert the left range into a 0-1 range


### PR DESCRIPTION
LogFontScalar.java was (erroneously?) using Math.sqrt instead of Math.log to compute the leftSpan.