### PR TITLE
fix LogFontScalar

### DIFF
--- a/kumo-core/src/main/java/com/kennycason/kumo/WordCloud.java
+++ b/kumo-core/src/main/java/com/kennycason/kumo/WordCloud.java
@@ -255,7 +255,7 @@ public class WordCloud {
         graphics.setRenderingHints(Word.getRenderingHints());
         
         final int frequency = wordFrequency.getFrequency();
-        final float fontHeight = this.fontScalar.scale(frequency, 0, maxFrequency);
+        final float fontHeight = this.fontScalar.scale(frequency, maxFrequency);
         final Font font = (wordFrequency.hasFont() ? wordFrequency.getFont() : kumoFont).getFont().deriveFont(fontHeight);
         final FontMetrics fontMetrics = graphics.getFontMetrics(font);
         

--- a/kumo-core/src/main/java/com/kennycason/kumo/font/scale/FontScalar.java
+++ b/kumo-core/src/main/java/com/kennycason/kumo/font/scale/FontScalar.java
@@ -4,5 +4,5 @@ package com.kennycason.kumo.font.scale;
  * Created by kenny on 6/30/14.
  */
 public interface FontScalar {
-    float scale(int n, int minValue, int maxValue);
+    float scale(int n, int maxValue);
 }

--- a/kumo-core/src/main/java/com/kennycason/kumo/font/scale/LinearFontScalar.java
+++ b/kumo-core/src/main/java/com/kennycason/kumo/font/scale/LinearFontScalar.java
@@ -9,17 +9,19 @@ public class LinearFontScalar implements FontScalar {
     private final int maxFont;
 
     public LinearFontScalar(final int minFont, final int maxFont) {
+        if (maxFont < minFont)
+            throw new IllegalArgumentException("maxFont cannot be smaller than minFont");
         this.minFont = minFont;
         this.maxFont = maxFont;
     }
 
     @Override
-    public float scale(final int value, final int minValue, final int maxValue) {
-        final float leftSpan = maxValue - minValue;
+    public float scale(final int value, final int maxValue) {
+        final float leftSpan = maxValue;
         final float rightSpan = maxFont - minFont;
 
         // Convert the left range into a 0-1 range
-        final float valueScaled = (value - minValue) / leftSpan;
+        final float valueScaled = value / leftSpan;
 
         // Convert the 0-1 range into a value in the right range.
         return minFont + (valueScaled * rightSpan);

--- a/kumo-core/src/main/java/com/kennycason/kumo/font/scale/LogFontScalar.java
+++ b/kumo-core/src/main/java/com/kennycason/kumo/font/scale/LogFontScalar.java
@@ -9,17 +9,19 @@ public class LogFontScalar implements FontScalar {
     private final int maxFont;
 
     public LogFontScalar(final int minFont, final int maxFont) {
+        if (maxFont < minFont)
+            throw new IllegalArgumentException("maxFont cannot be smaller than minFont");
         this.minFont = minFont;
         this.maxFont = maxFont;
     }
 
     @Override
-    public float scale(final int value, final int minValue, final int maxValue) {
-        final double leftSpan = Math.log(maxValue) - Math.log(minValue);
+    public float scale(final int value, final int maxValue) {
+        final double leftSpan = (maxValue == 1 ? 1 : Math.log(maxValue));
         final double rightSpan = maxFont - minFont;
 
         // Convert the left range into a 0-1 range
-        final double valueScaled = (Math.log(value) - Math.log(minValue)) / leftSpan;
+        final double valueScaled = (value == 1 ? 1 : Math.log(value)) / leftSpan;
 
         // Convert the 0-1 range into a value in the right range.
         return (float) (minFont + (valueScaled * rightSpan));

--- a/kumo-core/src/main/java/com/kennycason/kumo/font/scale/SqrtFontScalar.java
+++ b/kumo-core/src/main/java/com/kennycason/kumo/font/scale/SqrtFontScalar.java
@@ -9,17 +9,19 @@ public class SqrtFontScalar implements FontScalar {
     private final int maxFont;
 
     public SqrtFontScalar(final int minFont, final int maxFont) {
+        if (maxFont < minFont)
+            throw new IllegalArgumentException("maxFont cannot be smaller than minFont");
         this.minFont = minFont;
         this.maxFont = maxFont;
     }
 
     @Override
-    public float scale(final int value, final int minValue, final int maxValue) {
-        final double leftSpan = Math.sqrt(maxValue) - Math.sqrt(minValue);
+    public float scale(final int value, final int maxValue) {
+        final double leftSpan = Math.sqrt(maxValue);
         final double rightSpan = maxFont - minFont;
 
         // Convert the left range into a 0-1 range
-        final double valueScaled = (Math.sqrt(value) - Math.sqrt(minValue)) / leftSpan;
+        final double valueScaled = Math.sqrt(value) / leftSpan;
 
         // Convert the 0-1 range into a value in the right range.
         return (float) (minFont + (valueScaled * rightSpan));

--- a/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LinearFontScalarTest.java
+++ b/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LinearFontScalarTest.java
@@ -8,9 +8,20 @@ public class LinearFontScalarTest {
     @Test
     public void testScale() {
         final LinearFontScalar fontScalar = new LinearFontScalar(-1, 13);
-        Assert.assertEquals(5.0f, fontScalar.scale(4, 1, 8), 0.0f);
+        Assert.assertEquals(6.0f, fontScalar.scale(4, 8), 0.0f);
 
         final LinearFontScalar fontScalar2 = new LinearFontScalar(0, 0);
-        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0, 0), 0.0f);
+        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0), 0.0f);
+
+    }
+
+    @Test
+    public void testNaN() {
+        final LinearFontScalar fontScalar = new LinearFontScalar(10, 40);
+
+        for (int i=0; i<6; i++)
+            for (int j=1; j<6; j++) {
+                Assert.assertNotEquals(Float.NaN, fontScalar.scale(i, j));
+            }
     }
 }

--- a/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LogFontScalarTest.java
+++ b/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LogFontScalarTest.java
@@ -8,9 +8,19 @@ public class LogFontScalarTest {
     @Test
     public void testScale() {
         final LogFontScalar fontScalar = new LogFontScalar(-1, 13);
-        Assert.assertEquals(8.333333f, fontScalar.scale(4, 1, 8), 0.0f);
+        Assert.assertEquals(8.333333f, fontScalar.scale(4, 8), 0.0f);
 
         final LogFontScalar fontScalar2 = new LogFontScalar(0, 0);
-        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0, 0), 0.0f);
+        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0), 0.0f);
+    }
+
+    @Test
+    public void testNaN() {
+        final LogFontScalar fontScalar = new LogFontScalar(10, 40);
+
+        for (int i=0; i<6; i++)
+            for (int j=1; j<6; j++) {
+                Assert.assertNotEquals(Float.NaN, fontScalar.scale(i, j));
+            }
     }
 }

--- a/kumo-core/src/test/java/com/kennycason/kumo/font/scale/SqrtFontScalarTest.java
+++ b/kumo-core/src/test/java/com/kennycason/kumo/font/scale/SqrtFontScalarTest.java
@@ -8,9 +8,19 @@ public class SqrtFontScalarTest {
     @Test
     public void testScale() {
         final SqrtFontScalar fontScalar = new SqrtFontScalar(-1, 13);
-        Assert.assertEquals(6.656854f, fontScalar.scale(4, 1, 8), 0.0f);
+        Assert.assertEquals(8.899495f, fontScalar.scale(4, 8), 0.0f);
 
         final SqrtFontScalar fontScalar2 = new SqrtFontScalar(0, 0);
-        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0, 0), 0.0f);
+        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0), 0.0f);
+    }
+
+    @Test
+    public void testNaN() {
+        final SqrtFontScalar fontScalar = new SqrtFontScalar(10, 40);
+
+        for (int i=0; i<6; i++)
+            for (int j=1; j<6; j++) {
+                Assert.assertNotEquals(Float.NaN, fontScalar.scale(i, j));
+            }
     }
 }


### PR DESCRIPTION
The `LogFontScaler` plain does not work with the param `minValue = 0` which is the only way the `FontScaler` Interface is used.

This PR does 2.5 things:
- remove the effectively unused `minValue` param from scale()
- fix the `LogFontScaler`
- add a sanity check for font sizes when creating a `FontScaler`

It also adds a test for each `FontScaler` implementation that asserts that `NaN` is never returned for sane input values (and some insane ones), because returning `NaN` crashes the programm with an `IlleagalArgumentException` down the line, which has happened to me a lot when using a large amount of words (>1000).